### PR TITLE
Missing dep: toml

### DIFF
--- a/fugit.opam
+++ b/fugit.opam
@@ -14,6 +14,7 @@ depends: [
   "calendar"
   "angstrom" {>= "0.14.0"}
   "alcotest" {with-test}
+  "toml"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
`toml` dependency missing.

I didn't install on a fresh switch, so there could be more.