### PR TITLE
Switch to Daypack-lib for duration and time parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
   - PINS="fugit:."
   - DISTRO="debian-stable"
   matrix:
-  - PACKAGE="fugit" OCAML_VERSION="4.06.0"
-  - PACKAGE="fugit" OCAML_VERSION="4.07.0"
+  - PACKAGE="fugit" OCAML_VERSION="4.10.1"
+  - PACKAGE="fugit" OCAML_VERSION="4.11.1"

--- a/fugit.opam
+++ b/fugit.opam
@@ -15,6 +15,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "alcotest" {with-test}
   "toml"
+  "daypack-lib" {= "0.0.1"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/fugit.opam
+++ b/fugit.opam
@@ -15,7 +15,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "alcotest" {with-test}
   "toml"
-  "daypack-lib" {= "0.0.1"}
+  "daypack-lib" {= "0.0.2"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/fugit.opam
+++ b/fugit.opam
@@ -15,6 +15,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "alcotest" {with-test}
   "toml"
+  "ptime"
   "daypack-lib" {= "0.0.2"}
 ]
 build: [

--- a/fugit.opam
+++ b/fugit.opam
@@ -7,7 +7,7 @@ tags: ["time" "notification" "tool"]
 homepage: "https://github.com/Drup/fugit"
 bug-reports: "https://github.com/Drup/fugit/issues"
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.10"}
   "dune" {build}
   "lwt" "fmt" "obus" "bos"
   "containers" "cmdliner"

--- a/fugit.opam
+++ b/fugit.opam
@@ -16,7 +16,7 @@ depends: [
   "alcotest" {with-test}
   "toml"
   "ptime"
-  "daypack-lib" {= "0.0.2"}
+  "daypack-lib" {= "0.0.4"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/config.ml
+++ b/src/config.ml
@@ -29,7 +29,9 @@ module Format = struct
     (T.key "message" |-- T.string)
   let duration =
     let create v = Fmt.strf "%a" Delay.pp_duration v in
-    let get x = CCResult.to_opt @@ Delay.parse_duration x in
+    let get x =
+      CCResult.to_opt @@ Delay.parse_duration @@ String.split_on_char ' ' x
+    in
     let set v _ = create v in
     (fun x -> x.duration) >$<
     T.optional "duration" (T.string |-- {T. create ; get ; set })

--- a/src/delay.ml
+++ b/src/delay.ml
@@ -315,7 +315,7 @@ let get_current_tz_offset_s () =
 
 let search_param =
   let open Daypack_lib in
-  Time_pattern.Years_ahead_start_unix_second {
+  Search_param.Years_ahead_start_unix_second {
     search_using_tz_offset_s = get_current_tz_offset_s ();
     start = Time.Current.cur_unix_second ();
     search_years_ahead = 5;
@@ -323,23 +323,23 @@ let search_param =
 
 let parse_durationl' l =
   let s = String.concat " " l in
-  Daypack_lib.Duration.Of_string.of_string s
+  Daypack_lib.Duration.of_string s
   |> Result.map duration_of_daypack_duration
 
 let parse_time_pointl' l =
   let open Daypack_lib in
   let s = String.concat " " l in
-  match Time_expr.Of_string.time_points_expr_of_string s with
+  match Time_expr.of_string s with
   | Ok x ->
-    (match Time_expr.Time_points_expr.next_match_unix_second search_param
+    (match Time_expr.next_match_time_slot search_param
              x with
     | Error msg -> Error msg
     | Ok x ->
       match x with
       | None -> Error "Failed to find a matching time point"
-      | Some x ->
+      | Some (time_slot_start, _time_slot_end) ->
         let cur = Time.Current.cur_unix_second () in
-        let diff = if x >= cur then Int64.sub x cur else 0L in
+        let diff = if time_slot_start >= cur then Int64.sub time_slot_start cur else 0L in
         Duration.of_seconds diff
         |> Result.get_ok
         |> duration_of_daypack_duration

--- a/src/delay.ml
+++ b/src/delay.ml
@@ -372,10 +372,7 @@ let parse_deadlinel l =
 
 let parse_deadline s =
   let l = String.split_on_char ' ' s in
-  match parse_durationl' l with
-  | Ok x -> Ok x
-  | Error _ ->
-    parse_time_pointl' l
+  parse_deadlinel l
 
 let parse l =
   let s = String.concat " " l in

--- a/src/dune
+++ b/src/dune
@@ -6,6 +6,8 @@
    lwt.unix fmt obus.notification
    containers cmdliner calendar
    angstrom toml bos
+   daypack-lib
+   ptime ptime.clock.os
   )
 )
 

--- a/src/fugit.ml
+++ b/src/fugit.ml
@@ -88,7 +88,7 @@ let may_parse_duration opts l =
   | Some _d, [] ->
     Lwt_result.return None
   | None, l ->
-    Lwt_result.lift (Delay.parse_deadlinel l) >|= (fun x -> Some x)
+    Lwt_result.lift (Delay.parse_deadline l) >|= (fun x -> Some x)
 
 let launch_delay { verbose; no_action; backend; _ } (n : Notif.t) =
   let prec = Delay.decide_precision n.delay.start n.delay.stop in

--- a/src/fugit.ml
+++ b/src/fugit.ml
@@ -88,7 +88,7 @@ let may_parse_duration opts l =
   | Some _d, [] ->
     Lwt_result.return None
   | None, l ->
-    Lwt_result.lift (Delay.parse_durationl l) >|= (fun x -> Some x)
+    Lwt_result.lift (Delay.parse_deadlinel l) >|= (fun x -> Some x)
 
 let launch_delay { verbose; no_action; backend; _ } (n : Notif.t) =
   let prec = Delay.decide_precision n.delay.start n.delay.stop in

--- a/test/unittest.ml
+++ b/test/unittest.ml
@@ -7,15 +7,12 @@ end
 let period : Period.t Alcotest.testable = (module Period)
 
 let periods =
-  let parse p s =
-    Angstrom.(parse_string ~consume:Consume.All (p <* end_of_input)) s
-  in
   let f s d =
     let open Alcotest in
     test_case d `Quick @@ fun () ->
     check (result period string) d
-      (parse Delay.Parsing.human_duration s)
-      (parse Delay.Parsing.iso8601_duration d)
+      (Delay.parse_duration @@ String.split_on_char ' ' s)
+      (Delay.Iso8601.parse s)
   in
   "Periods", [
     f "1s" "PT1S";

--- a/test/unittest.ml
+++ b/test/unittest.ml
@@ -11,8 +11,8 @@ let periods =
     let open Alcotest in
     test_case d `Quick @@ fun () ->
     check (result period string) d
+      (Delay.Iso8601.parse d)
       (Delay.parse_duration @@ String.split_on_char ' ' s)
-      (Delay.Iso8601.parse s)
   in
   "Periods", [
     f "1s" "PT1S";


### PR DESCRIPTION
Making a PR as Daypack-lib just got published on opam. Overall still fairly rough (both daypack-lib and the PR itself), so no drama if you intend to reject it.

---

Duration parsing is fairly standard and similar compared to before, examples:
```
$ fugit notify --no-action 1 hour 2 minutes
Alert will trigger in 1 hour and 2 minutes.
$ fugit notify --no-action 1 h 2 min
Alert will trigger in 1 hour and 2 minutes.
$ fugit notify --no-action 1 h 2 m
Alert will trigger in 1 hour and 2 minutes.
$ fugit notify --no-action 1 h 2 m 20 seconds
Alert will trigger in 1 hour, 2 minutes and 20 seconds.
$ fugit notify --no-action 100 seconds
Alert will trigger in 1 minute and 40 seconds.
$ fugit notify --no-action 200 minutes 100 seconds
Alert will trigger in 3 hours, 21 minutes and 40 seconds.
$ fugit notify --no-action 20 day 7 hours
Alert will trigger in 20 days and 7 hours.
```

But numbers must be integers, i.e. can't do "1.5 hour".

---

Time parsing is a new addition, examples:
```
$ fugit notify --no-action 2020-09-01 00:00
Alert will trigger in 6 days, 1 hour, 51 minutes and 20 seconds.
$ fugit notify --no-action 5pm
Alert will trigger in 18 hours, 51 minutes and 15 seconds.
$ fugit notify --no-action 10am
Alert will trigger in 11 hours, 51 minutes and 5 seconds.
$ fugit notify --no-action 6pm
Alert will trigger in 19 hours, 51 minutes and 1 second.
$ fugit notify --no-action thursday 15:00
Alert will trigger in 1 day, 16 hours, 50 minutes and 50 seconds.
$ fugit notify --no-action thu 15:00
Alert will trigger in 1 day, 16 hours, 50 minutes and 44 seconds.
$ fugit notify --no-action sun 15:00
Alert will trigger in 4 days, 16 hours, 50 minutes and 40 seconds.
$ fugit notify --no-action sep 1 15:00
Alert will trigger in 6 days, 16 hours, 50 minutes and 33 seconds.
$ fugit notify --no-action sep 5 15:00
Alert will trigger in 10 days, 16 hours, 50 minutes and 29 seconds.
$ fugit notify --no-action 2020 sep 5 15:00
Alert will trigger in 10 days, 16 hours, 50 minutes and 24 seconds.
$ fugit notify --no-action 2021 sep 5 15:00
Alert will trigger in 375 days, 16 hours, 50 minutes and 22 seconds.
```

---

Adding `in` at the front will force it to parse input as duration, adding `at` at the front will force it to parse input as time.

If neither keyword is specified, then it tries to parse input as duration first, then tries to parse input as time.